### PR TITLE
Also copy bbio. Without, a buffer may stay on top of the real bio.

### DIFF
--- a/ssl/ech.c
+++ b/ssl/ech.c
@@ -3900,7 +3900,7 @@ int ech_swaperoo(SSL *s)
     BIO_up_ref(s->rbio);
     /* This one doesn't seem to be needed nor up-ref'd */
     /* but not fully sure.... */
-    /* s->bbio=tmp_outer.bbio; */
+    s->bbio=tmp_outer.bbio;
 
     /* Fields we (for now) need the same in both */
     s->rlayer=tmp_outer.rlayer;


### PR DESCRIPTION
Without this fix, openssl pushes a buffer bio and doesn't pop it later
